### PR TITLE
update CORE_VERSION in jdk-21

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-ARG CORE_VERSION="latest"
+ARG CORE_VERSION="1.0.1"
 FROM 416670754337.dkr.ecr.eu-west-2.amazonaws.com/ci-core-runtime:${CORE_VERSION}
 
 RUN dnf update -y && \


### PR DESCRIPTION
Change core version to retrieve later image when image build is triggered